### PR TITLE
Add CMakeLists.txt for ESP-IDF builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+
+if(ESP_PLATFORM)
+   # Build as an ESP-IDF component
+   idf_component_register(
+      SRCS "src/improv.cpp"
+      INCLUDE_DIRS "src"
+      # TODO: It would be nice to have this conditional only if arduino is already used as a component
+      REQUIRES arduino
+   )
+   return()
+endif()
+
+project(improv VERSION 1.2.2)


### PR DESCRIPTION
This allows this library to be used as an ESP-IDF component. But it has an `if` statement in there in case others want to do other Cmake-y things with this lib (as is done in some other [components](https://github.com/bblanchon/ArduinoJson/blob/6.x/CMakeLists.txt))