### PR TITLE
Adding STATE_SCANNING to support WiFi scanning over BLE

### DIFF
--- a/src/improv.h
+++ b/src/improv.h
@@ -33,6 +33,7 @@ enum State : uint8_t {
   STATE_AUTHORIZED = 0x02,
   STATE_PROVISIONING = 0x03,
   STATE_PROVISIONED = 0x04,
+  STATE_SCANNING = 0x05,
 };
 
 enum Command : uint8_t {


### PR DESCRIPTION
We're using the RPC command to scan for WiFi networks over Bluetooth and just need the Bluetooth state to match. The docs don't say anything about scanning for WiFi APs over BLE but it was straight-forward to support using the protocol specified both in BLE and Serial doc sections.