### PR TITLE
Reduce memory allocations when building RPC response

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# Example Programs
+
+Build and run the examples with the following command:
+
+```bash
+# g++ -std=c++11 ../src/improv.cpp <example_file> && ./a.out
+
+g++ -std=c++11 ../src/improv.cpp time_execution.cpp && ./a.out
+g++ -std=c++11 ../src/improv.cpp show_rpc_response.cpp && ./a.out
+```
+
+## Show RPC Response
+
+Show the constructed frame for a given command and vector string input. Prints the hex values as well as the frame and data length.
+
+## Time Execution
+
+Measure the time it takes to run 100.000 iterations of the library's functions. Prints it for the total and per call time.

--- a/examples/show_rpc_response.cpp
+++ b/examples/show_rpc_response.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+
+#include "../src/improv.h"
+
+int main(int argc, char *argv[]) {
+  std::string msg_1 = "hi there";
+  std::string msg_2 = "jojo";
+  std::vector<std::string> msgs = {msg_1, msg_2};
+
+  std::vector<uint8_t> out = improv::build_rpc_response(improv::Command::GET_DEVICE_INFO, msgs);
+
+  auto flags = std::cout.flags();
+  for (auto i : out) {
+    std::cout << std::hex << std::setfill('0') << std::setw(sizeof(out[0]) * 2) << (0xFF & i) << " ";
+  }
+  std::cout << std::endl;
+  std::cout.flags(flags);
+
+  std::cout << "Frame len: " << out.size() << std::endl;
+  std::cout << "Data len: " << (msg_1.length() + msg_2.length()) << std::endl;
+}

--- a/examples/time_execution.cpp
+++ b/examples/time_execution.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+
+#include "../src/improv.h"
+
+int main(int argc, char *argv[]) {
+  std::string msg_1 = "hi there";
+  std::string msg_2 = "jojo";
+  std::vector<std::string> msgs = {msg_1, msg_2};
+
+  const uint32_t iterations = 100000;
+  printf("Running %u iterations for build_rpc_response\n", iterations);
+
+  std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < iterations; i++) {
+    std::vector<uint8_t> out = improv::build_rpc_response(improv::Command::GET_DEVICE_INFO, msgs);
+  }
+  std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
+  // Add 1000s separator if available on system
+  std::cout.imbue(std::locale(""));
+  std::cout << "Total: " << (end - start).count() / 1000 << " µs" << std::endl;
+  std::cout << "per run: " << (end - start).count() / iterations << " ns" << std::endl;
+}


### PR DESCRIPTION
Why:

- Make library more efficient
  - Reduce mallocs to reduce memory fragementation
  - Reduce mallocs to reduce runtime

This change addresses the need by:

- Reserve required space at start of function call
- Copy data into reserved memory

The time results, averaged over 7 runs is given below. It results in a ~3.5 time reduction and several fewer memory allocations depending on the input data.

|          | Total (µs) | per run (ns) |
|----------|------------|--------------|
| Existing | 183,627    | 1,836        |
| New      | 53,464     | 534          |