### PR TITLE
Allow server authentication to be set during provisioning

### DIFF
--- a/src/improv.cpp
+++ b/src/improv.cpp
@@ -30,7 +30,7 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_c
     }
   }
 
-  if (command == WIFI_SETTINGS) {
+  if (command == WIFI_SETTINGS || command == SET_SERVER_AUTH) {
     uint8_t ssid_length = data[2];
     uint8_t ssid_start = 3;
     size_t ssid_end = ssid_start + ssid_length;

--- a/src/improv.h
+++ b/src/improv.h
@@ -42,6 +42,7 @@ enum Command : uint8_t {
   GET_CURRENT_STATE = 0x02,
   GET_DEVICE_INFO = 0x03,
   GET_WIFI_NETWORKS = 0x04,
+  SET_SERVER_AUTH = 0x05,
   BAD_CHECKSUM = 0xFF,
 };
 


### PR DESCRIPTION
This MR will probably require rework and discuss to conform with the different use cases posed by Improv users.
- It would probably also make sense to update the documentation with the optional SET_SERVER_AUTH command. 
- Another name for the command might also make sense?
- Create a second struct for SET_SERVER_AUTH command?
- Create another command to set the server URL to connect to?

### Initial implementation

Why:

- For API access authantication allow
  - username and password to be set
  - token to be set
- Allow combination with WIFI_SETTINGS command

This change addresses the need by:

- Add command type
- Parse username and password of SET_SERVER_AUTH command