### PR TITLE
feat: Add support for custom commands

### DIFF
--- a/src/improv.cpp
+++ b/src/improv.cpp
@@ -1,4 +1,5 @@
 #include "improv.h"
+#include <stdio.h>
 #include <cstring>
 
 namespace improv {
@@ -8,15 +9,14 @@ ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_che
 }
 
 ImprovCommand parse_data_command(Command command, const uint8_t *data, size_t length) {
-  ImprovCommand cmd;
   std::vector<std::vector<uint8_t>> data_fields;
   size_t field_start = 3;
   size_t field_end = 0;
   do {
       size_t field_end = field_start + data[field_start - 1];
+      printf("field_end: %zu\n", field_end);
       if (field_end > length) {
-          cmd.command = UNKNOWN;
-          return cmd;
+          return {.command = UNKNOWN};
       }
       data_fields.push_back(std::vector<uint8_t>(data + field_start, data + field_end));
       field_start = field_end + 1;

--- a/src/improv.cpp
+++ b/src/improv.cpp
@@ -7,6 +7,23 @@ ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_che
   return parse_improv_data(data.data(), data.size(), check_checksum);
 }
 
+ImprovCommand parse_data_command(Command command, const uint8_t *data, size_t length) {
+  ImprovCommand cmd;
+  std::vector<std::vector<uint8_t>> data_fields;
+  size_t field_start = 3;
+  size_t field_end;
+  do {
+      size_t field_end = field_start + data[field_start - 1];
+      if (field_end > length) {
+          cmd.command = UNKNOWN;
+          return cmd;
+      }
+      data_fields.push_back(std::vector<uint8_t>(data + field_start, data + field_end));
+      field_start = field_end + 1;
+  } while (field_end < length);
+  return {.command = command, .data = data_fields};
+}
+
 ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum) {
   ImprovCommand improv_command;
   Command command = (Command) data[0];
@@ -31,26 +48,8 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_c
     }
   }
 
-  if (command == WIFI_SETTINGS) {
-    uint8_t ssid_length = data[2];
-    uint8_t ssid_start = 3;
-    size_t ssid_end = ssid_start + ssid_length;
-    if (ssid_end > length) {
-      improv_command.command = UNKNOWN;
-      return improv_command;
-    }
-
-    uint8_t pass_length = data[ssid_end];
-    size_t pass_start = ssid_end + 1;
-    size_t pass_end = pass_start + pass_length;
-    if (pass_end > length) {
-      improv_command.command = UNKNOWN;
-      return improv_command;
-    }
-
-    std::string ssid(data + ssid_start, data + ssid_end);
-    std::string password(data + pass_start, data + pass_end);
-    return {.command = command, .ssid = ssid, .password = password};
+  if (command == WIFI_SETTINGS || command == CUSTOM) {
+    return parse_data_command(command, data, length);
   }
 
   improv_command.command = command;

--- a/src/improv.cpp
+++ b/src/improv.cpp
@@ -11,7 +11,7 @@ ImprovCommand parse_data_command(Command command, const uint8_t *data, size_t le
   ImprovCommand cmd;
   std::vector<std::vector<uint8_t>> data_fields;
   size_t field_start = 3;
-  size_t field_end;
+  size_t field_end = 0;
   do {
       size_t field_end = field_start + data[field_start - 1];
       if (field_end > length) {

--- a/src/improv.cpp
+++ b/src/improv.cpp
@@ -1,5 +1,4 @@
 #include "improv.h"
-#include <stdio.h>
 #include <cstring>
 
 namespace improv {

--- a/src/improv.h
+++ b/src/improv.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdint.h>
 #ifdef ARDUINO
 #include <Arduino.h>
 #endif  // ARDUINO

--- a/src/improv.h
+++ b/src/improv.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #ifdef ARDUINO
 #include <Arduino.h>
 #endif  // ARDUINO
@@ -42,6 +43,7 @@ enum Command : uint8_t {
   GET_CURRENT_STATE = 0x02,
   GET_DEVICE_INFO = 0x03,
   GET_WIFI_NETWORKS = 0x04,
+  CUSTOM = 0x80,
   BAD_CHECKSUM = 0xFF,
 };
 
@@ -57,8 +59,19 @@ enum ImprovSerialType : uint8_t {
 
 struct ImprovCommand {
   Command command;
-  std::string ssid;
-  std::string password;
+  std::vector<std::vector<uint8_t>> data;
+  std::string ssid() const {
+    if (!data.empty() && !data[0].empty() && command == WIFI_SETTINGS) {
+        return std::string(data[0].begin(), data[0].end());
+    }
+    return "";
+  }
+  std::string password() const {
+    if (data.size() > 1 && !data[1].empty() && command == WIFI_SETTINGS) {
+        return std::string(data[1].begin(), data[1].end());
+    }
+    return "";
+  }
 };
 
 ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum = true);


### PR DESCRIPTION
This PR adds supports for custom RPC commands (that support any amount of data fields) so Improv can be extended by the user for custom use cases (such as cases where more credentials are required).

I added a new `CUSTOM` command type to the `Command` enum, allowing for the introduction of custom command handling. Following the same logic, I updated the `ImprovCommand` struct to replace `ssid` and `password` fields with a vector of data fields (but added methods to retrieve `ssid` and `password` from the data fields, ensuring backward compatibility).